### PR TITLE
feat(upload): Add saucectl optional upload description

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ fastlane add_plugin saucectl
 
 ## About fastlane-plugin-saucectl
 
-The purpose of this plugin is to simplify the set up, configuration, upload, and execution of espresso and XCUITest on the Sauce Labs platform by utilizing fastlane which will enable you to test your iOS and Android apps at scale.
+The purpose of this plugin is to simplify the set-up, configuration, upload, and execution of espresso and XCUITest on the Sauce Labs platform by utilizing fastlane which will enable you to test your iOS and Android apps at scale.
 
-**IMPORTANT:** To use this plugin to execute UI tests on Sauce Labs, your test class names must proceed with `Spec`, `Specs`, `Tests`, or `Test`, for example `ExampleSpec`, `ExampleSpecs`, `ExampleTest`, or `ExampleTests`. Your test case names must also begin with `test`, for example `testIDoSomething`, `testIDoSomethingElse`. This is so that the the plugin can search for test classes and their included test cases.
+**IMPORTANT:** To use this plugin to execute UI tests on Sauce Labs, your test class names must proceed with `Spec`, `Specs`, `Tests`, or `Test`, for example `ExampleSpec`, `ExampleSpecs`, `ExampleTest`, or `ExampleTests`. Your test case names must also begin with `test`, for example `testIDoSomething`, `testIDoSomethingElse`. This is so that the plugin can search for test classes and their included test cases.
 
 Failure to do this will result in missing test classes and test cases from your test run.
 
 **For a detailed introduction to each of the actions available within this plugin, please see the [documentation](https://ianrhamilton.github.io/fastlane-plugin-saucectl/#fastlane-plugin-saucectl)**.
 
-| Available Actions   | Description                                                                                                                                                                                                  |
-|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Available Actions     | Description                                                                                                                                                                                                  |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `install_saucectl`    | Downloads the Sauce Labs saucectl cli binary for test execution. Optionally specify the [version](https://github.com/saucelabs/saucectl/releases/) you wish to install or automatically download the latest. |
 | `sauce_upload`        | Upload test artifacts to sauce labs storage                                                                                                                                                                  | 
 | `sauce_config`        | Create SauceLabs configuration file for test execution based on given parameters                                                                                                                             |

--- a/lib/fastlane/plugin/saucectl/actions/sauce_upload_action.rb
+++ b/lib/fastlane/plugin/saucectl/actions/sauce_upload_action.rb
@@ -79,6 +79,14 @@ module Fastlane
                                        type: String,
                                        verify_block: proc do |value|
                                          UI.user_error!(@messages['sauce_api_key_error']) unless value && !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_description,
+                                       description: "A description of the artifact (optional, 1-255 chars)",
+                                       optional: true,
+                                       is_string: true,
+                                       type: String,
+                                       verify_block: proc do |value|
+                                         UI.user_error!(@messages['description_malformed']) unless value && !value.empty? && value.to_s.length < 256
                                        end)
         ]
       end

--- a/lib/fastlane/plugin/saucectl/helper/api.rb
+++ b/lib/fastlane/plugin/saucectl/helper/api.rb
@@ -67,12 +67,15 @@ module Fastlane
       end
 
       def upload
-        UI.message("⏳ Uploading \"#{@config[:app]}\" upload to Sauce Labs.")
+        UI.message("⏳ Uploading \"#{@config[:app]}\" to Sauce Labs.")
         path = 'v1/storage/upload'
         https, url = build_http_request_for(path)
         request = Net::HTTP::Post.new(url)
         request['Authorization'] = "Basic #{@encoded_auth_string}"
         form_data = [['payload', File.open(@config[:file])], ['name', @config[:app]]]
+        unless @config[:app_description].nil?
+          form_data.append(['description', @config[:app_description]])
+        end
         request.set_form(form_data, 'multipart/form-data')
         response = https.request(request)
         UI.success("✅ Successfully uploaded app to sauce labs: \n #{response.body}") if response.code.eql?('201')

--- a/lib/fastlane/plugin/saucectl/strings/messages.yml
+++ b/lib/fastlane/plugin/saucectl/strings/messages.yml
@@ -10,3 +10,4 @@ sauce_api_key_error: "No sauce labs access key provided, set using: sauce_access
 supported_regions: ['us', 'eu']
 accepted_file_types: ['.apk', '.aab', '.ipa', '.zip']
 missing_file_name: "Please specify the name of the app that you wish to query on sauce storage"
+description_malformed: "Description was empty or > 255 characters. Do not set app_description or set using app_description: 'Foo'"

--- a/lib/fastlane/plugin/saucectl/version.rb
+++ b/lib/fastlane/plugin/saucectl/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Saucectl
-    VERSION = '0.1.4'.freeze
+    VERSION = '0.1.5'.freeze
   end
 end

--- a/spec/sauce_upload_action_spec.rb
+++ b/spec/sauce_upload_action_spec.rb
@@ -121,5 +121,40 @@ describe Fastlane::Actions::SauceUploadAction do
 
       end.to raise_error("No sauce labs access key provided, set using: sauce_access_key: '1234' or consider setting your credentials as environment variables.")
     end
+
+    it "should raise an error when description is defined but empty" do
+      expect do
+        Fastlane::FastFile.new.parse("lane :test do
+          sauce_upload({
+                     platform: 'android',
+                     sauce_username: 'foo',
+                     sauce_access_key: 'bar',
+                     app: 'Android.MyCustomApp.apk',
+                     file: '#{@file}',
+                     region: 'eu',
+                     app_description: ''
+                   })
+          end").runner.execute(:test)
+
+      end.to raise_error("Description was empty or > 255 characters. Do not set app_description or set using app_description: 'Foo'")
+    end
+
+    it "should raise an error when description is longer than 255 characters" do
+      expect do
+        Fastlane::FastFile.new.parse("lane :test do
+          sauce_upload({
+                     platform: 'android',
+                     sauce_username: 'foo',
+                     sauce_access_key: 'bar',
+                     app: 'Android.MyCustomApp.apk',
+                     file: '#{@file}',
+                     region: 'eu',
+                     app_description: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata '
+                   })
+          end").runner.execute(:test)
+
+      end.to raise_error("Description was empty or > 255 characters. Do not set app_description or set using app_description: 'Foo'")
+    end
+
   end
 end


### PR DESCRIPTION
* Added a new optional upload field `app_description` that can be used to set the online `description` of an artifact.
* Minor corrections in `README.md`
* Bumped version to 0.1.5

Closes #10 